### PR TITLE
FIKS-168 Tilpasser til bruk sammen med Spring Boot 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-libPipelineMvnCentral(dtProjectId: "299ec640-dc1f-42ed-842a-c266e8f09c19")
+libPipelineMvnCentralJdk17(dtProjectId: "299ec640-dc1f-42ed-842a-c266e8f09c19")

--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@
 
 
 Klient som brukes for å sende inn ASiC-E meldinger til Fiks IO mottakstjenesten over HTTP
+
+## Versjoner
+Versjon 3.x krever Java 17 eller høyere. Har du ikke mulighet for å bruke det må du holde deg på v. 2.x
+
+| Versjon | Java baseline | Spring Boot versjon | Status      | 
+|---------|---------------|---------------------|-------------|
+| 3.x     | Java 17       | 3.X                 | Aktiv       | 
+| 2.X     | Java 11       | 2.X                 | Vedlikehold |

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-send-klient</artifactId>
-  <version>2.1.5-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>FIKS IO send-klient</name>
   <description>Klient for å sende meldinger til FIKS IO</description>
   <url>https://github.com/ks-no/fiks-io</url>
@@ -19,7 +19,7 @@
     <url>https://github.com/ks-no/fiks-io-send-klient</url>
   </scm>
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -28,10 +28,9 @@
     <jackson.version>2.14.2</jackson.version>
     <revision>1.2.8</revision>
     <lombok.version>1.18.24</lombok.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <junit-jupiter.version>5.9.2</junit-jupiter.version>
-    <jetty-client.version>9.4.50.v20221201</jetty-client.version>
-    <validation-api.version>2.0.1.Final</validation-api.version>
+    <jetty-client.version>11.0.14</jetty-client.version>
+    <validation-api.version>3.0.2</validation-api.version>
     <logback-classic.version>1.4.6</logback-classic.version>
     <commons-io.version>2.11.0</commons-io.version>
     <maskinporten-client.version>3.0.0</maskinporten-client.version>
@@ -69,8 +68,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
       <version>${validation-api.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <logback-classic.version>1.4.6</logback-classic.version>
     <commons-io.version>2.11.0</commons-io.version>
     <maskinporten-client.version>3.0.0</maskinporten-client.version>
+    <assertj.version>3.24.2</assertj.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -109,6 +110,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>no.ks.fiks.pom</groupId>
     <artifactId>fiks-ekstern-super-pom</artifactId>
-    <version>1.0.20</version>
+    <version>1.0.21</version>
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-send-klient</artifactId>

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
@@ -7,10 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
-import org.eclipse.jetty.client.util.InputStreamContentProvider;
-import org.eclipse.jetty.client.util.InputStreamResponseListener;
-import org.eclipse.jetty.client.util.MultiPartContentProvider;
-import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.client.util.*;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -50,10 +47,10 @@ public class FiksIOUtsendingKlient implements Closeable {
     }
 
     public SendtMeldingApiModel send(@NonNull MeldingSpesifikasjonApiModel metadata, @NonNull Optional<InputStream> data) {
-        try (MultiPartContentProvider contentProvider = new MultiPartContentProvider()) {
-            contentProvider.addFieldPart("metadata", new StringContentProvider("application/json", serialiser(metadata), StandardCharsets.UTF_8), null);
+        try (MultiPartRequestContent contentProvider = new MultiPartRequestContent()) {
+            contentProvider.addFieldPart("metadata", new StringRequestContent("application/json", serialiser(metadata), StandardCharsets.UTF_8), null);
             data.ifPresent(inputStream ->
-                    contentProvider.addFilePart("data", UUID.randomUUID().toString(), new InputStreamContentProvider(inputStream), null));
+                    contentProvider.addFilePart("data", UUID.randomUUID().toString(), new InputStreamRequestContent(inputStream), null));
 
             InputStreamResponseListener listener = new InputStreamResponseListener();
             final Request request = requestFactory.createSendToFiksIORequest(contentProvider);

--- a/src/main/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategy.java
+++ b/src/main/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategy.java
@@ -25,9 +25,9 @@ public class IntegrasjonAuthenticationStrategy implements AuthenticationStrategy
 
     @Override
     public void setAuthenticationHeaders(Request request) {
-        request.header(HttpHeader.AUTHORIZATION, "Bearer " + getAccessToken())
-                .header(INTEGRASJON_ID, integrasjonId.toString())
-                .header(INTEGRASJON_PASSWORD, integrasjonPassord);
+        request.headers(m -> m.add(HttpHeader.AUTHORIZATION, "Bearer " + getAccessToken())
+                .add(INTEGRASJON_ID, integrasjonId.toString())
+                .add(INTEGRASJON_PASSWORD, integrasjonPassord));
     }
 
     private String getAccessToken() {

--- a/src/main/java/no/ks/fiks/io/klient/MeldingSpesifikasjonApiModel.java
+++ b/src/main/java/no/ks/fiks/io/klient/MeldingSpesifikasjonApiModel.java
@@ -1,16 +1,17 @@
 package no.ks.fiks.io.klient;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Value;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
 
 @Value
 @Builder
 public class MeldingSpesifikasjonApiModel {
-    @NotNull private UUID avsenderKontoId;
+    @NotNull
+    private UUID avsenderKontoId;
     @NotNull private UUID mottakerKontoId;
     @NotNull private String meldingType;
     private UUID svarPaMelding;

--- a/src/main/java/no/ks/fiks/io/klient/RequestFactory.java
+++ b/src/main/java/no/ks/fiks/io/klient/RequestFactory.java
@@ -1,6 +1,5 @@
 package no.ks.fiks.io.klient;
 
-import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.Request;
 
 import java.io.Closeable;
@@ -15,5 +14,5 @@ public interface RequestFactory extends Closeable {
      * @param contentProvider innhold som skal sendes
      * @return en ny {@link Request}
      */
-    Request createSendToFiksIORequest(ContentProvider contentProvider);
+    Request createSendToFiksIORequest(Request.Content contentProvider);
 }

--- a/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
+++ b/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
@@ -2,7 +2,6 @@ package no.ks.fiks.io.klient;
 
 import lombok.Builder;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.http.HttpMethod;
 
@@ -31,12 +30,12 @@ public class RequestFactoryImpl implements RequestFactory {
     }
 
     @Override
-    public Request createSendToFiksIORequest(ContentProvider contentProvider) {
+    public Request createSendToFiksIORequest(Request.Content contentProvider) {
         return client.newRequest(hostName, portNumber)
-                                .scheme(scheme)
-                                .method(HttpMethod.POST)
-                                .path(BASE_PATH + "send")
-                                .content(contentProvider);
+                .scheme(scheme)
+                .method(HttpMethod.POST)
+                .path(BASE_PATH + "send")
+                .body(contentProvider);
     }
 
     @Override

--- a/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
+++ b/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
@@ -5,7 +5,6 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.time.Duration;
 
@@ -22,7 +21,7 @@ public class RequestFactoryImpl implements RequestFactory {
         this.hostName = hostName;
         this.portNumber = portNumber;
 
-        this.client = new HttpClient(new SslContextFactory.Client());
+        this.client = new HttpClient();
         this.client.setIdleTimeout(Duration.ofMinutes(1).toMillis());
         try {
             client.start();

--- a/src/test/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategyTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategyTest.java
@@ -3,37 +3,49 @@ package no.ks.fiks.io.klient;
 import no.ks.fiks.maskinporten.AccessTokenRequest;
 import no.ks.fiks.maskinporten.MaskinportenklientOperations;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 
+import static no.ks.fiks.io.klient.IntegrasjonAuthenticationStrategy.INTEGRASJON_ID;
+import static no.ks.fiks.io.klient.IntegrasjonAuthenticationStrategy.INTEGRASJON_PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class IntegrasjonAuthenticationStrategyTest {
 
+    @Captor
+    private ArgumentCaptor<Consumer<HttpFields.Mutable>> headerCaptor;
+
     @Test
     void setAuthenticationHeaders(@Mock MaskinportenklientOperations maskinportenklient, @Mock Request request) {
         final UUID integrasjonId = UUID.randomUUID();
         final String integrasjonPassord = "passord";
-        final String accessToken = "accessToken";
 
-        when(maskinportenklient.getAccessToken(isA(AccessTokenRequest.class))).thenReturn(accessToken);
-        when(request.header(eq(HttpHeader.AUTHORIZATION), anyString())).thenReturn(request);
-        when(request.header(eq(IntegrasjonAuthenticationStrategy.INTEGRASJON_ID), anyString())).thenReturn(request);
-        when(request.header(eq(IntegrasjonAuthenticationStrategy.INTEGRASJON_PASSWORD), anyString())).thenReturn(request);
+        when(request.headers(any())).thenReturn(request);
+        when(maskinportenklient.getAccessToken(isA(AccessTokenRequest.class))).thenReturn("token");
 
         new IntegrasjonAuthenticationStrategy(maskinportenklient, integrasjonId, integrasjonPassord)
                 .setAuthenticationHeaders(request);
 
+        verify(request).headers(headerCaptor.capture());
+        var mutable = new HttpFields.Mutable() {
+        };
+        headerCaptor.getValue().accept(mutable);
+        final Set<String> fieldNamesCollection = mutable.getFieldNamesCollection();
+        assertThat(fieldNamesCollection).hasSameElementsAs(Arrays.asList(HttpHeader.AUTHORIZATION.asString(), INTEGRASJON_ID, INTEGRASJON_PASSWORD));
         verify(maskinportenklient).getAccessToken(isA(AccessTokenRequest.class));
-        verify(request).header(eq(HttpHeader.AUTHORIZATION), anyString());
-        verify(request).header(eq(IntegrasjonAuthenticationStrategy.INTEGRASJON_ID), anyString());
-        verify(request).header(eq(IntegrasjonAuthenticationStrategy.INTEGRASJON_PASSWORD), anyString());
         verifyNoMoreInteractions(maskinportenklient, request);
     }
 }

--- a/src/test/java/no/ks/fiks/io/klient/RequestFactoryTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/RequestFactoryTest.java
@@ -1,10 +1,10 @@
 package no.ks.fiks.io.klient;
 
 import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.client.util.StringRequestContent;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RequestFactoryTest {
 
@@ -18,10 +18,10 @@ class RequestFactoryTest {
                                                               .hostName(hostName)
                                                               .portNumber(portNumber)
                                                               .build()
-                                                              .createSendToFiksIORequest(new StringContentProvider("stuff"));
-        assertEquals(RequestFactoryImpl.BASE_PATH + "send", sendToFiksIORequest.getPath());
-        assertEquals(hostName, sendToFiksIORequest.getHost());
-        assertEquals(scheme, sendToFiksIORequest.getScheme());
-        assertEquals(portNumber, sendToFiksIORequest.getPort());
+                                                              .createSendToFiksIORequest(new StringRequestContent("stuff"));
+        assertThat(sendToFiksIORequest.getPath()).isEqualTo(RequestFactoryImpl.BASE_PATH + "send");
+        assertThat(sendToFiksIORequest.getHost()).isEqualTo(hostName);
+        assertThat(sendToFiksIORequest.getScheme()).isEqualTo(scheme);
+        assertThat(sendToFiksIORequest.getPort()).isEqualTo(portNumber);
     }
 }

--- a/src/test/java/no/ks/fiks/io/klient/SendtMeldingApiModelTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/SendtMeldingApiModelTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.util.Collections;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SendtMeldingApiModelTest {
 
@@ -26,9 +26,9 @@ class SendtMeldingApiModelTest {
                 .meldingType(testInfo.getDisplayName())
                 .build();
         final String jsonString = mapper.writeValueAsString(meldingApiModel);
-        assertNotNull(jsonString);
+        assertThat(jsonString).isNotNull();
         SendtMeldingApiModel deserializedMeldingModel = mapper.readValue(jsonString, SendtMeldingApiModel.class);
-        assertEquals(meldingApiModel, deserializedMeldingModel);
+        assertThat(deserializedMeldingModel).isEqualTo(meldingApiModel);
     }
 
 }


### PR DESCRIPTION
- FIKS-168 Gjør kompatibel med Spring Boot 3.x
- Fjerner en del deprekerte kall + bruker assertj for assertions
