### PR TITLE
Bytt ut jetty client med hc 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,6 @@
       <version>${commons-io.version}</version>
     </dependency>
     <dependency>
-      <groupId>no.ks.fiks</groupId>
-      <artifactId>maskinporten-client</artifactId>
-      <version>${maskinporten-client.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
       <version>${apache-httpclient5.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-send-klient</artifactId>
-  <version>3.0.3-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <name>FIKS IO send-klient</name>
   <description>Klient for å sende meldinger til FIKS IO</description>
   <url>https://github.com/ks-no/fiks-io</url>
@@ -24,19 +24,19 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <enforcer.jdk.version>${java.version}</enforcer.jdk.version>
-    <mockito.version>5.5.0</mockito.version>
-    <jackson.version>2.15.2</jackson.version>
-    <revision>1.2.8</revision>
-    <lombok.version>1.18.24</lombok.version>
-    <junit-jupiter.version>5.10.0</junit-jupiter.version>
-    <jetty-client.version>11.0.16</jetty-client.version>
-    <validation-api.version>3.0.2</validation-api.version>
-    <logback-classic.version>1.4.11</logback-classic.version>
-    <commons-io.version>2.14.0</commons-io.version>
-    <maskinporten-client.version>3.1.4</maskinporten-client.version>
+
+    <apache-httpclient5.version>5.2.1</apache-httpclient5.version>
     <assertj.version>3.24.2</assertj.version>
-    <slf4j.version>2.0.9</slf4j.version>
+    <commons-io.version>2.14.0</commons-io.version>
+    <jackson.version>2.15.2</jackson.version>
+    <junit-jupiter.version>5.10.0</junit-jupiter.version>
+    <logback-classic.version>1.4.11</logback-classic.version>
+    <lombok.version>1.18.24</lombok.version>
+    <maskinporten-client.version>3.1.4</maskinporten-client.version>
+    <mockito.version>5.5.0</mockito.version>
     <mockserver.version>5.15.0</mockserver.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <validation-api.version>3.0.2</validation-api.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -81,11 +81,6 @@
       <version>${validation-api.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-      <version>${jetty-client.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -102,6 +97,11 @@
       <groupId>no.ks.fiks</groupId>
       <artifactId>maskinporten-client</artifactId>
       <version>${maskinporten-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>${apache-httpclient5.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/no/ks/fiks/io/klient/AuthenticationStrategy.java
+++ b/src/main/java/no/ks/fiks/io/klient/AuthenticationStrategy.java
@@ -1,7 +1,7 @@
 package no.ks.fiks.io.klient;
 
-import org.eclipse.jetty.client.api.Request;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 
 public interface AuthenticationStrategy {
-    void setAuthenticationHeaders(Request request);
+    void setAuthenticationHeaders(ClassicHttpRequest request);
 }

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
@@ -5,44 +5,47 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.client.api.Response;
-import org.eclipse.jetty.client.util.InputStreamRequestContent;
-import org.eclipse.jetty.client.util.InputStreamResponseListener;
-import org.eclipse.jetty.client.util.MultiPartRequestContent;
-import org.eclipse.jetty.client.util.StringRequestContent;
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.util.TimeValue;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static org.eclipse.jetty.http.HttpStatus.isClientError;
-import static org.eclipse.jetty.http.HttpStatus.isServerError;
 
 @Slf4j
 public class FiksIOUtsendingKlient implements Closeable {
 
     private final RequestFactory requestFactory;
     private final AuthenticationStrategy authenticationStrategy;
-    private final Function<Request, Request> requestInterceptor;
-
+    private final Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor;
+    private final CloseableHttpClient client;
     private final ObjectMapper objectMapper;
 
     FiksIOUtsendingKlient(@NonNull final RequestFactory requestFactory,
                           @NonNull AuthenticationStrategy authenticationStrategy,
-                          @NonNull Function<Request, Request> requestInterceptor,
+                          @NonNull Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor,
                           @NonNull final ObjectMapper objectMapper) {
         this.requestFactory = requestFactory;
         this.authenticationStrategy = authenticationStrategy;
         this.requestInterceptor = requestInterceptor;
         this.objectMapper = objectMapper;
+        this.client = HttpClients.custom()
+                .disableAutomaticRetries()
+                .useSystemProperties()
+                .evictIdleConnections(TimeValue.of(Duration.ofMinutes(1L)))
+                .build();
     }
 
     public static FiksIOUtsendingKlientBuilder builder() {
@@ -50,34 +53,32 @@ public class FiksIOUtsendingKlient implements Closeable {
     }
 
     public SendtMeldingApiModel send(@NonNull MeldingSpesifikasjonApiModel metadata, @NonNull Optional<InputStream> data) {
-        MultiPartRequestContent multipartRequestContent = createMultiPartContent(metadata, data);
-        InputStreamResponseListener listener = new InputStreamResponseListener();
-        final Request request = requestFactory.createSendToFiksIORequest(multipartRequestContent);
+        final ClassicHttpRequest request = requestFactory.createSendToFiksIORequest(createMultiPartContent(metadata, data));
         authenticationStrategy.setAuthenticationHeaders(request);
+        requestInterceptor.apply(request);
 
-        requestInterceptor.apply(request).send(listener);
-
-        try (InputStream listenerInputStream = listener.getInputStream()) {
-            Response response = listener.get(1, TimeUnit.HOURS);
-            if (isClientError(response.getStatus()) || isServerError(response.getStatus())) {
-                int status = response.getStatus();
-                String content = IOUtils.toString(listenerInputStream, StandardCharsets.UTF_8);
-                throw new FiksIOHttpException(String.format("HTTP-feil under sending av melding (%d): %s", status, content), status, content);
-            }
-            return objectMapper.readValue(listenerInputStream, SendtMeldingApiModel.class);
-        } catch (InterruptedException | TimeoutException | ExecutionException | IOException e) {
+        try {
+            return client.execute(request, response -> {
+                final int responseCode = response.getCode();
+                log.debug("Response status: {}", responseCode);
+                if(responseCode >= HttpStatus.SC_BAD_REQUEST) {
+                    final var contentAsString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+                    throw new FiksIOHttpException(String.format("HTTP-feil under sending av melding (%d): %s", responseCode, contentAsString), responseCode, contentAsString);
+                }
+                return objectMapper.readValue(response.getEntity().getContent(), SendtMeldingApiModel.class);
+            });
+        } catch (IOException e) {
             throw new RuntimeException("Feil under invokering av FIKS IO api", e);
         }
 
     }
 
-    private MultiPartRequestContent createMultiPartContent(@NonNull MeldingSpesifikasjonApiModel metadata, @NonNull Optional<InputStream> data) {
-        var multipartRequestContent = new MultiPartRequestContent();
-        multipartRequestContent.addFieldPart("metadata", new StringRequestContent("application/json", serialiser(metadata), StandardCharsets.UTF_8), null);
+    private HttpEntity createMultiPartContent(@NonNull MeldingSpesifikasjonApiModel metadata, @NonNull Optional<InputStream> data) {
+        var multipartRequestContentBuilder = MultipartEntityBuilder.create()
+                .addBinaryBody("metadata", serialiser(metadata).getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON, null);
         data.ifPresent(inputStream ->
-                multipartRequestContent.addFilePart("data", UUID.randomUUID().toString(), new InputStreamRequestContent(inputStream), null));
-        multipartRequestContent.close();
-        return multipartRequestContent;
+                multipartRequestContentBuilder.addPart("data", new InputStreamBody(inputStream, (String) null)));
+        return multipartRequestContentBuilder.build();
     }
 
     private String serialiser(@NonNull Object metadata) {
@@ -90,6 +91,6 @@ public class FiksIOUtsendingKlient implements Closeable {
 
     @Override
     public void close() throws IOException {
-        requestFactory.close();
+        client.close();
     }
 }

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
@@ -8,25 +8,20 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.entity.mime.InputStreamBody;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.hc.core5.util.TimeValue;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
 
-
 @Slf4j
 public class FiksIOUtsendingKlient implements Closeable {
-
     private final RequestFactory requestFactory;
     private final AuthenticationStrategy authenticationStrategy;
     private final Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor;
@@ -36,16 +31,13 @@ public class FiksIOUtsendingKlient implements Closeable {
     FiksIOUtsendingKlient(@NonNull final RequestFactory requestFactory,
                           @NonNull AuthenticationStrategy authenticationStrategy,
                           @NonNull Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor,
-                          @NonNull final ObjectMapper objectMapper) {
+                          @NonNull final ObjectMapper objectMapper,
+                          @NonNull final CloseableHttpClient client) {
         this.requestFactory = requestFactory;
         this.authenticationStrategy = authenticationStrategy;
         this.requestInterceptor = requestInterceptor;
         this.objectMapper = objectMapper;
-        this.client = HttpClients.custom()
-                .disableAutomaticRetries()
-                .useSystemProperties()
-                .evictIdleConnections(TimeValue.of(Duration.ofMinutes(1L)))
-                .build();
+        this.client = client;
     }
 
     public static FiksIOUtsendingKlientBuilder builder() {
@@ -61,7 +53,7 @@ public class FiksIOUtsendingKlient implements Closeable {
             return client.execute(request, response -> {
                 final int responseCode = response.getCode();
                 log.debug("Response status: {}", responseCode);
-                if(responseCode >= HttpStatus.SC_BAD_REQUEST) {
+                if (responseCode >= HttpStatus.SC_BAD_REQUEST) {
                     final var contentAsString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                     throw new FiksIOHttpException(String.format("HTTP-feil under sending av melding (%d): %s", responseCode, contentAsString), responseCode, contentAsString);
                 }
@@ -76,8 +68,7 @@ public class FiksIOUtsendingKlient implements Closeable {
     private HttpEntity createMultiPartContent(@NonNull MeldingSpesifikasjonApiModel metadata, @NonNull Optional<InputStream> data) {
         var multipartRequestContentBuilder = MultipartEntityBuilder.create()
                 .addBinaryBody("metadata", serialiser(metadata).getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_JSON, null);
-        data.ifPresent(inputStream ->
-                multipartRequestContentBuilder.addPart("data", new InputStreamBody(inputStream, (String) null)));
+        data.ifPresent(inputStream -> multipartRequestContentBuilder.addPart("data", new InputStreamBody(inputStream, ContentType.APPLICATION_OCTET_STREAM)));
         return multipartRequestContentBuilder.build();
     }
 

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientBuilder.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientBuilder.java
@@ -3,9 +3,12 @@ package no.ks.fiks.io.klient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.util.TimeValue;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 /**
@@ -13,8 +16,6 @@ import java.util.function.Function;
  */
 @Slf4j
 public class FiksIOUtsendingKlientBuilder {
-
-    private HttpClient httpClient;
 
     private String scheme = "https";
 
@@ -28,7 +29,13 @@ public class FiksIOUtsendingKlientBuilder {
 
     private ObjectMapper objectMapper;
 
-    public FiksIOUtsendingKlientBuilder withHttpClient(@NonNull final HttpClient httpClient) {
+    private CloseableHttpClient httpClient = HttpClients.custom()
+            .disableAutomaticRetries()
+            .useSystemProperties()
+            .evictIdleConnections(TimeValue.of(Duration.ofMinutes(1L)))
+            .build();
+
+    public FiksIOUtsendingKlientBuilder withHttpClient(@NonNull final CloseableHttpClient httpClient) {
         this.httpClient = httpClient;
         return this;
     }
@@ -69,7 +76,8 @@ public class FiksIOUtsendingKlientBuilder {
                 createRequestFactory(),
                 authenticationStrategy,
                 getOrCreateRequestInterceptor(),
-                getOrCreateObjectMapper()
+                getOrCreateObjectMapper(),
+                httpClient
         );
     }
 

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientBuilder.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientBuilder.java
@@ -3,9 +3,8 @@ package no.ks.fiks.io.klient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 
 import java.util.function.Function;
 
@@ -25,7 +24,7 @@ public class FiksIOUtsendingKlientBuilder {
 
     private AuthenticationStrategy authenticationStrategy;
 
-    private Function<Request, Request> requestInterceptor;
+    private Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor;
 
     private ObjectMapper objectMapper;
 
@@ -54,7 +53,7 @@ public class FiksIOUtsendingKlientBuilder {
         return this;
     }
 
-    public FiksIOUtsendingKlientBuilder withRequestInterceptor(Function<Request, Request> requestInterceptor) {
+    public FiksIOUtsendingKlientBuilder withRequestInterceptor(Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor) {
         this.requestInterceptor = requestInterceptor;
         return this;
     }
@@ -82,7 +81,7 @@ public class FiksIOUtsendingKlientBuilder {
                                  .build();
     }
 
-    private Function<Request, Request> getOrCreateRequestInterceptor() {
+    private Function<ClassicHttpRequest, ClassicHttpRequest> getOrCreateRequestInterceptor() {
         return requestInterceptor == null ? request -> request : requestInterceptor;
     }
 

--- a/src/main/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategy.java
+++ b/src/main/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategy.java
@@ -2,8 +2,9 @@ package no.ks.fiks.io.klient;
 
 import no.ks.fiks.maskinporten.AccessTokenRequest;
 import no.ks.fiks.maskinporten.MaskinportenklientOperations;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.http.HttpHeader;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
 
 import java.util.UUID;
 
@@ -24,10 +25,10 @@ public class IntegrasjonAuthenticationStrategy implements AuthenticationStrategy
     }
 
     @Override
-    public void setAuthenticationHeaders(Request request) {
-        request.headers(m -> m.add(HttpHeader.AUTHORIZATION, "Bearer " + getAccessToken())
-                .add(INTEGRASJON_ID, integrasjonId.toString())
-                .add(INTEGRASJON_PASSWORD, integrasjonPassord));
+    public void setAuthenticationHeaders(ClassicHttpRequest request) {
+        request.addHeader(new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken()));
+        request.addHeader(new BasicHeader(INTEGRASJON_ID, integrasjonId.toString()));
+        request.addHeader(new BasicHeader(INTEGRASJON_PASSWORD, integrasjonPassord));
     }
 
     private String getAccessToken() {

--- a/src/main/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategy.java
+++ b/src/main/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategy.java
@@ -1,12 +1,11 @@
 package no.ks.fiks.io.klient;
 
-import no.ks.fiks.maskinporten.AccessTokenRequest;
-import no.ks.fiks.maskinporten.MaskinportenklientOperations;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
 
 import java.util.UUID;
+import java.util.function.Supplier;
 
 public class IntegrasjonAuthenticationStrategy implements AuthenticationStrategy {
 
@@ -14,24 +13,21 @@ public class IntegrasjonAuthenticationStrategy implements AuthenticationStrategy
 
     static final String INTEGRASJON_PASSWORD = "IntegrasjonPassord";
 
-    private final MaskinportenklientOperations maskinportenklient;
+    private final Supplier<String> maskinportenTokenSupplier;
     private final UUID integrasjonId;
     private final String integrasjonPassord;
 
-    public IntegrasjonAuthenticationStrategy(MaskinportenklientOperations maskinportenklient, UUID integrasjonId, String integrasjonPassord) {
-        this.maskinportenklient = maskinportenklient;
+    public IntegrasjonAuthenticationStrategy(Supplier<String> maskinportenTokenSupplier, UUID integrasjonId, String integrasjonPassord) {
+        this.maskinportenTokenSupplier = maskinportenTokenSupplier;
         this.integrasjonId = integrasjonId;
         this.integrasjonPassord = integrasjonPassord;
     }
 
     @Override
     public void setAuthenticationHeaders(ClassicHttpRequest request) {
-        request.addHeader(new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken()));
+        request.addHeader(new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer " + maskinportenTokenSupplier.get()));
         request.addHeader(new BasicHeader(INTEGRASJON_ID, integrasjonId.toString()));
         request.addHeader(new BasicHeader(INTEGRASJON_PASSWORD, integrasjonPassord));
     }
 
-    private String getAccessToken() {
-        return maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope("ks:fiks").build());
-    }
 }

--- a/src/main/java/no/ks/fiks/io/klient/RequestFactory.java
+++ b/src/main/java/no/ks/fiks/io/klient/RequestFactory.java
@@ -1,18 +1,17 @@
 package no.ks.fiks.io.klient;
 
-import org.eclipse.jetty.client.api.Request;
-
-import java.io.Closeable;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpEntity;
 
 /**
  * Factory for nye send requester
  */
-public interface RequestFactory extends Closeable {
+public interface RequestFactory {
 
     /**
-     * Oppretter ny {@link Request} for å sende til fiks-io
+     * Oppretter ny {@link ClassicHttpRequest} for å sende til fiks-io
      * @param contentProvider innhold som skal sendes
-     * @return en ny {@link Request}
+     * @return en ny {@link ClassicHttpRequest}
      */
-    Request createSendToFiksIORequest(Request.Content contentProvider);
+    ClassicHttpRequest createSendToFiksIORequest(HttpEntity contentProvider);
 }

--- a/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
+++ b/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
@@ -1,15 +1,18 @@
 package no.ks.fiks.io.klient;
 
 import lombok.Builder;
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.http.HttpMethod;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.util.TimeValue;
 
+import java.net.URI;
 import java.time.Duration;
 
 public class RequestFactoryImpl implements RequestFactory {
     static final String BASE_PATH = "/fiks-io/api/v1/";
-    private final HttpClient client;
     private final String scheme;
     private final String hostName;
     private final Integer portNumber;
@@ -19,31 +22,17 @@ public class RequestFactoryImpl implements RequestFactory {
         this.scheme = scheme;
         this.hostName = hostName;
         this.portNumber = portNumber;
-
-        this.client = new HttpClient();
-        this.client.setIdleTimeout(Duration.ofMinutes(1).toMillis());
-        try {
-            client.start();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     @Override
-    public Request createSendToFiksIORequest(Request.Content contentProvider) {
-        return client.newRequest(hostName, portNumber)
-                .scheme(scheme)
-                .method(HttpMethod.POST)
-                .path(BASE_PATH + "send")
-                .body(contentProvider);
+    public ClassicHttpRequest createSendToFiksIORequest(final HttpEntity contentProvider) {
+        return createPostRequest(contentProvider);
     }
 
-    @Override
-    public void close() {
-        try {
-            client.stop();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private HttpPost createPostRequest(final HttpEntity contentProvider){
+        final HttpPost httpPost = new HttpPost(URI.create(scheme + "://" + hostName + ":" + portNumber + BASE_PATH + "send"));
+        httpPost.setEntity(contentProvider);
+        return httpPost;
     }
+
 }

--- a/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
+++ b/src/main/java/no/ks/fiks/io/klient/RequestFactoryImpl.java
@@ -2,14 +2,10 @@ package no.ks.fiks.io.klient;
 
 import lombok.Builder;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.util.TimeValue;
 
 import java.net.URI;
-import java.time.Duration;
 
 public class RequestFactoryImpl implements RequestFactory {
     static final String BASE_PATH = "/fiks-io/api/v1/";

--- a/src/test/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientTest.java
@@ -56,7 +56,7 @@ class FiksIOUtsendingKlientTest {
                 .build();
         try(InputStream payload = FiksIOUtsendingKlientTest.class.getResourceAsStream("/small.pdf")) {
             assertThat(fiksIOUtsendingKlient.send(meldingSpesifikasjonApiModel, Optional.ofNullable(payload))).isInstanceOfAny(SendtMeldingApiModel.class);
-            clientAndServer.verify(request(SEND_PATH));
+            clientAndServer.verify(request(SEND_PATH).withMethod("POST"));
         }
     }
 }

--- a/src/test/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/FiksIOUtsendingKlientTest.java
@@ -2,13 +2,9 @@ package no.ks.fiks.io.klient;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import no.ks.fiks.maskinporten.AccessTokenRequest;
-import no.ks.fiks.maskinporten.MaskinportenklientOperations;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.junit.jupiter.MockServerExtension;
@@ -22,7 +18,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -33,8 +28,6 @@ class FiksIOUtsendingKlientTest {
             .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     private static final String SEND_PATH = RequestFactoryImpl.BASE_PATH + "send";
-    @Mock
-    private MaskinportenklientOperations maskinportenklientOperations;
 
     @DisplayName("Sender en pakke")
     @Test
@@ -44,7 +37,6 @@ class FiksIOUtsendingKlientTest {
                 .avsenderKontoId(UUID.randomUUID())
                 .mottakerKontoId(UUID.randomUUID())
                 .build();
-        Mockito.when(maskinportenklientOperations.getAccessToken(any(AccessTokenRequest.class))).thenReturn("token");
         clientAndServer.when(request().withMethod("POST").withPath(SEND_PATH))
                 .respond(request -> response()
                         .withStatusCode(HttpStatusCode.ACCEPTED_202.code())
@@ -60,12 +52,11 @@ class FiksIOUtsendingKlientTest {
                 .withHostName("localhost")
                 .withPortNumber(clientAndServer.getPort())
                 .withScheme("http")
-                .withAuthenticationStrategy(new IntegrasjonAuthenticationStrategy(maskinportenklientOperations, UUID.randomUUID(), "passord"))
+                .withAuthenticationStrategy(new IntegrasjonAuthenticationStrategy(() -> "token", UUID.randomUUID(), "passord"))
                 .build();
         try(InputStream payload = FiksIOUtsendingKlientTest.class.getResourceAsStream("/small.pdf")) {
             assertThat(fiksIOUtsendingKlient.send(meldingSpesifikasjonApiModel, Optional.ofNullable(payload))).isInstanceOfAny(SendtMeldingApiModel.class);
             clientAndServer.verify(request(SEND_PATH));
-            Mockito.verify(maskinportenklientOperations).getAccessToken(any(AccessTokenRequest.class));
         }
     }
 }

--- a/src/test/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategyTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategyTest.java
@@ -1,7 +1,5 @@
 package no.ks.fiks.io.klient;
 
-import no.ks.fiks.maskinporten.AccessTokenRequest;
-import no.ks.fiks.maskinporten.MaskinportenklientOperations;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
@@ -30,20 +28,17 @@ class IntegrasjonAuthenticationStrategyTest {
 
     @DisplayName("Setter headers for integrasjonspålogging")
     @Test
-    void setAuthenticationHeaders(@Mock MaskinportenklientOperations maskinportenklient, @Mock ClassicHttpRequest request) {
+    void setAuthenticationHeaders(@Mock ClassicHttpRequest request) {
         final UUID integrasjonId = UUID.randomUUID();
         final String integrasjonPassord = "passord";
 
-        when(maskinportenklient.getAccessToken(isA(AccessTokenRequest.class))).thenReturn("token");
-
-        new IntegrasjonAuthenticationStrategy(maskinportenklient, integrasjonId, integrasjonPassord)
+        new IntegrasjonAuthenticationStrategy(() -> "token", integrasjonId, integrasjonPassord)
                 .setAuthenticationHeaders(request);
 
         verify(request, times(3)).addHeader(headerCaptor.capture());
         final var headers = headerCaptor.getAllValues();
         assertThat(headers).hasSize(3);
         assertThat(headers.stream().map(BasicHeader::getName).collect(Collectors.toList())).hasSameElementsAs(Arrays.asList(HttpHeaders.AUTHORIZATION, INTEGRASJON_ID, INTEGRASJON_PASSWORD));
-        verify(maskinportenklient).getAccessToken(isA(AccessTokenRequest.class));
-        verifyNoMoreInteractions(maskinportenklient, request);
+        verifyNoMoreInteractions(request);
     }
 }

--- a/src/test/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategyTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/IntegrasjonAuthenticationStrategyTest.java
@@ -2,9 +2,10 @@ package no.ks.fiks.io.klient;
 
 import no.ks.fiks.maskinporten.AccessTokenRequest;
 import no.ks.fiks.maskinporten.MaskinportenklientOperations;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.http.HttpHeader;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -13,9 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
-import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static no.ks.fiks.io.klient.IntegrasjonAuthenticationStrategy.INTEGRASJON_ID;
 import static no.ks.fiks.io.klient.IntegrasjonAuthenticationStrategy.INTEGRASJON_PASSWORD;
@@ -26,25 +26,23 @@ import static org.mockito.Mockito.*;
 class IntegrasjonAuthenticationStrategyTest {
 
     @Captor
-    private ArgumentCaptor<Consumer<HttpFields.Mutable>> headerCaptor;
+    private ArgumentCaptor<BasicHeader> headerCaptor;
 
+    @DisplayName("Setter headers for integrasjonspålogging")
     @Test
-    void setAuthenticationHeaders(@Mock MaskinportenklientOperations maskinportenklient, @Mock Request request) {
+    void setAuthenticationHeaders(@Mock MaskinportenklientOperations maskinportenklient, @Mock ClassicHttpRequest request) {
         final UUID integrasjonId = UUID.randomUUID();
         final String integrasjonPassord = "passord";
 
-        when(request.headers(any())).thenReturn(request);
         when(maskinportenklient.getAccessToken(isA(AccessTokenRequest.class))).thenReturn("token");
 
         new IntegrasjonAuthenticationStrategy(maskinportenklient, integrasjonId, integrasjonPassord)
                 .setAuthenticationHeaders(request);
 
-        verify(request).headers(headerCaptor.capture());
-        var mutable = new HttpFields.Mutable() {
-        };
-        headerCaptor.getValue().accept(mutable);
-        final Set<String> fieldNamesCollection = mutable.getFieldNamesCollection();
-        assertThat(fieldNamesCollection).hasSameElementsAs(Arrays.asList(HttpHeader.AUTHORIZATION.asString(), INTEGRASJON_ID, INTEGRASJON_PASSWORD));
+        verify(request, times(3)).addHeader(headerCaptor.capture());
+        final var headers = headerCaptor.getAllValues();
+        assertThat(headers).hasSize(3);
+        assertThat(headers.stream().map(BasicHeader::getName).collect(Collectors.toList())).hasSameElementsAs(Arrays.asList(HttpHeaders.AUTHORIZATION, INTEGRASJON_ID, INTEGRASJON_PASSWORD));
         verify(maskinportenklient).getAccessToken(isA(AccessTokenRequest.class));
         verifyNoMoreInteractions(maskinportenklient, request);
     }

--- a/src/test/java/no/ks/fiks/io/klient/RequestFactoryTest.java
+++ b/src/test/java/no/ks/fiks/io/klient/RequestFactoryTest.java
@@ -1,27 +1,31 @@
 package no.ks.fiks.io.klient;
 
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.client.util.StringRequestContent;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RequestFactoryTest {
 
     @Test
-    void createSendToFiksIORequest() {
+    void createSendToFiksIORequest() throws URISyntaxException {
         final String scheme = "http";
         final String hostName = "localhost";
         final int portNumber = 9999;
-        final Request sendToFiksIORequest = RequestFactoryImpl.builder()
+
+        final var sendToFiksIORequest = RequestFactoryImpl.builder()
                                                               .scheme(scheme)
                                                               .hostName(hostName)
                                                               .portNumber(portNumber)
                                                               .build()
-                                                              .createSendToFiksIORequest(new StringRequestContent("stuff"));
+                                                              .createSendToFiksIORequest(new StringEntity("stuff"));
         assertThat(sendToFiksIORequest.getPath()).isEqualTo(RequestFactoryImpl.BASE_PATH + "send");
-        assertThat(sendToFiksIORequest.getHost()).isEqualTo(hostName);
-        assertThat(sendToFiksIORequest.getScheme()).isEqualTo(scheme);
-        assertThat(sendToFiksIORequest.getPort()).isEqualTo(portNumber);
+        final URI uri = sendToFiksIORequest.getUri();
+        assertThat(uri.getHost()).isEqualTo(hostName);
+        assertThat(uri.getScheme()).isEqualTo(scheme);
+        assertThat(uri.getPort()).isEqualTo(portNumber);
     }
 }


### PR DESCRIPTION
- Fjerner avhengighet av Jetty

Siden vi allerede er avhengig av hc5 ved henting av maskinporten token kan vi like godt bruke det til sending også.
