### PR TITLE
Vi venter til vi kan lese data fra stream, før vi henter klient fra connection pool

### DIFF
--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
@@ -29,6 +29,8 @@ public class FiksIOUtsendingKlient implements Closeable {
     private final CloseableHttpClient client;
     private final ObjectMapper objectMapper;
 
+    private final static int END_OF_STREAM = -1;
+
     FiksIOUtsendingKlient(@NonNull final RequestFactory requestFactory,
                           @NonNull AuthenticationStrategy authenticationStrategy,
                           @NonNull Function<ClassicHttpRequest, ClassicHttpRequest> requestInterceptor,
@@ -66,7 +68,7 @@ public class FiksIOUtsendingKlient implements Closeable {
     private SendtMeldingApiModel send(@NonNull MeldingSpesifikasjonApiModel metadata, @NonNull InputStream data) {
         try (PushbackInputStream pis = new PushbackInputStream(data)) {
             int read = pis.read();
-            if (read == -1) {
+            if (read == END_OF_STREAM) {
                 throw new RuntimeException("Klarte ikke å lsse innhold i fil");
             }
             pis.unread(read);

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
@@ -69,9 +69,7 @@ public class FiksIOUtsendingKlient implements Closeable {
             }
             pis.unread(read);
 
-            var multipartRequestContentBuilder = getMultipartEntityBuilder(metadata);
-            multipartRequestContentBuilder.addBinaryBody(MULTIPART_DATA, pis, ContentType.APPLICATION_OCTET_STREAM, UUID.randomUUID().toString());
-            HttpEntity httpEntity =  multipartRequestContentBuilder.build();
+            HttpEntity httpEntity =  getMultipartEntityBuilder(metadata).addBinaryBody(MULTIPART_DATA, pis, ContentType.APPLICATION_OCTET_STREAM, UUID.randomUUID().toString()).build();
 
             return sendMelding(httpEntity);
         } catch (IOException e) {

--- a/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
+++ b/src/main/java/no/ks/fiks/io/klient/FiksIOUtsendingKlient.java
@@ -69,7 +69,7 @@ public class FiksIOUtsendingKlient implements Closeable {
         try (PushbackInputStream pis = new PushbackInputStream(data)) {
             int read = pis.read();
             if (read == END_OF_STREAM) {
-                throw new RuntimeException("Klarte ikke å lsse innhold i fil");
+                throw new IllegalArgumentException("Klarte ikke å lese innhold i fil");
             }
             pis.unread(read);
 


### PR DESCRIPTION
Vi oppdaget at vi kan komme i en deadl lock dersom vi ber om connections fra apache client pool før vi kan lese data fra innkommende stream. Løser dette med bruk av pushbackinputstream