### PR TITLE
bumpet deps og erstattet mockserver dependency pga. sårbarheter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>no.ks.fiks.pom</groupId>
     <artifactId>fiks-ekstern-super-pom</artifactId>
-    <version>1.2.5</version>
+    <version>1.4.0</version>
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-send-klient</artifactId>
@@ -25,18 +25,18 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <enforcer.jdk.version>${java.version}</enforcer.jdk.version>
 
-    <apache-httpclient5.version>5.4.1</apache-httpclient5.version>
-    <assertj.version>3.26.3</assertj.version>
-    <commons-io.version>2.17.0</commons-io.version>
-    <jackson.version>2.18.1</jackson.version>
-    <junit-jupiter.version>5.11.3</junit-jupiter.version>
-    <logback-classic.version>1.5.12</logback-classic.version>
-    <lombok.version>1.18.24</lombok.version>
+    <apache-httpclient5.version>5.4.4</apache-httpclient5.version>
+    <assertj.version>3.27.3</assertj.version>
+    <apache-commons-io.version>2.19.0</apache-commons-io.version>
+    <jackson.version>2.18.3</jackson.version>
+    <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    <logback-classic.version>1.5.18</logback-classic.version>
+    <lombok.version>1.18.38</lombok.version>
     <maskinporten-client.version>3.1.4</maskinporten-client.version>
-    <mockito.version>5.14.2</mockito.version>
-    <mockserver.version>5.15.0</mockserver.version>
+    <mockito.version>5.15.2</mockito.version>
+    <mockserver.version>5.14.0</mockserver.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <validation-api.version>3.1.0</validation-api.version>
+    <validation-api.version>3.1.1</validation-api.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${commons-io.version}</version>
+      <version>${apache-commons-io.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
@@ -123,7 +123,7 @@
     </dependency>
     <dependency>
       <groupId>org.mock-server</groupId>
-      <artifactId>mockserver-junit-jupiter</artifactId>
+      <artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
       <version>${mockserver.version}</version>
       <scope>test</scope>
       <exclusions>


### PR DESCRIPTION
**Oppdateringer:**
	•	Parent POM oppgradert fra 1.2.5 til 1.4.0 
	•	Flere avhengigheter oppgradert:
	•	apache-httpclient5 → 5.4.4
	•	assertj → 3.27.3
	•	commons-io → apache-commons-io (2.19.0)
	•	jackson → 2.18.3
	•	junit-jupiter → 5.11.4
	•	logback-classic → 1.5.18
	•	lombok → 1.18.38
	•	mockito → 5.15.2
	•	validation-api → 3.1.1

**Endringer i artifact-navn:**
	•	commons-io endret til apache-commons-io (unngår forvirring med fiks-io-commons).
	•	mockserver-junit-jupiter byttet til mockserver-junit-jupiter-no-dependencies (fjernet sårbarheter pga. transitive avhengigheter.)